### PR TITLE
Bugfix: set user-agent on label download

### DIFF
--- a/cs_harvester/add/css.py
+++ b/cs_harvester/add/css.py
@@ -9,9 +9,7 @@ harvesting.
 import os
 import re
 import sys
-from time import sleep
 import email
-import urllib
 import argparse
 import logging
 import sqlite3
@@ -153,22 +151,11 @@ def sync_list():
 
 
 def read_label(path):
-    logger = get_logger()
     url = "".join((ARCHIVE_PREFIX, path))
 
-    attempts = 0
-    # address timeout error by retrying with increasingly larger delays
-    while attempts < 6:
-        try:
-            with network.set_astropy_useragent():
-                label = pds4_read(url, lazy_load=True, quiet=True).label
-            break
-        except urllib.error.URLError as e:
-            logger.error(str(e))
-            attempts += 1
-            sleep(3 + 2**attempts)  # retry, but not too soon
-    else:
-        raise LabelError("5 failed attempts reading " + url)
+    fn = network.download_file(url)
+    label = pds4_read(fn, lazy_load=True, quiet=True).label
+    os.unlink(fn)
 
     return label
 
@@ -183,7 +170,7 @@ def new_labels(db, listfile):
         Database of ingested labels (``harvester_db``).
 
     listfile : str
-        Look for new labels in this file.
+        Look for new labels in this file.  It is expected to be gzipped.
 
     Returns
     -------
@@ -199,7 +186,7 @@ def new_labels(db, listfile):
     with gzip.open(listfile, "rt") as inf:
         for line in inf:
             line_count += 1
-            if re.match(".*data_calibrated/.*\.xml\n$", line):
+            if re.match(".*data_calibrated/.*\\.xml\n$", line):
                 if "collection" in line:
                     continue
                 calibrated_count += 1

--- a/cs_harvester/network.py
+++ b/cs_harvester/network.py
@@ -2,11 +2,15 @@
 Set HTTP User-Agent parameter.
 """
 
+import urllib
+from time import sleep
 from contextlib import contextmanager
 import requests as req
-from astropy.utils.data import conf as astropy_conf
-from . import __version__
+from astropy.utils.data import conf as astropy_conf, download_file as _download_file
 
+from .exceptions import LabelError
+from .logger import get_logger
+from . import __version__
 
 user_agent = f"CATCH-SIS Harvester {__version__}"
 
@@ -45,3 +49,45 @@ def set_astropy_useragent():
 
     with astropy_conf.set_temp("default_http_user_agent", user_agent):
         yield
+
+
+def download_file(url: str, max_attempts: int = 5) -> str:
+    """Download a file from a URL and save.
+
+
+    Parameters
+    ----------
+
+    url : str
+        The URL.
+
+    max_attempts : int, optional
+        Re-try failed downloads ``max_attempts`` times with an increasing delay
+        between each attempt.
+
+
+    Returns
+    -------
+    filename : str
+        The local file name of the saved data.
+
+    """
+
+    logger = get_logger()
+
+    attempts = 0
+    while attempts < max_attempts:
+        try:
+            with set_astropy_useragent():
+                file_name = _download_file(url, cache=False, show_progress=False)
+            break
+        except urllib.error.URLError as e:
+            logger.error(str(e))
+            attempts += 1
+            if attempts >= max_attempts:
+                raise LabelError(
+                    f"Failed to download {url} in {attempts} attempts"
+                ) from e
+            sleep(3 + 2**attempts)  # retry, but not too soon
+
+    return file_name


### PR DESCRIPTION
User-Agent was not set when downloading files.  Fix by downloading ourselves, rather than relying on pds4_tools to do so.